### PR TITLE
Relax upper bounds for library and test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 /.cabal-sandbox
 /cabal.sandbox.config
 /cabal.project.freeze
+/cabal.project.local
 
 # nix
 /result

--- a/list-zipper.cabal
+++ b/list-zipper.cabal
@@ -30,7 +30,7 @@ library
                     , deriving-compat >= 0.5 && < 0.6
                     , lens >= 4 && < 5
                     , comonad >= 5.0 && < 6.0
-                    , semigroupoids >=5.1 && <5.3
+                    , semigroupoids >=5.1 && <5.4
                     , semigroups >=0.16 && <0.19
                     , mtl >=2.2 && <2.3
                     , transformers >=0.4.1 && <5.5
@@ -50,17 +50,17 @@ library
 
 test-suite          tests
 
-  build-depends:      QuickCheck >= 2.9.2 && < 2.13
+  build-depends:      QuickCheck >= 2.9.2 && < 2.14
                     , base >= 4.8 && < 5
                     , checkers >= 0.4.6 && < 0.5
                     , list-zipper
-                    , lens >= 4 && < 4.18
+                    , lens >= 4 && < 4.19
                     , tasty >= 0.11 && < 1.2
                     , tasty-hunit >= 0.9 && < 0.11
                     , tasty-quickcheck >= 0.8.4 && < 0.11
-                    , hedgehog >= 0.6 && < 0.7
-                    , hedgehog-fn >= 0.6 && < 0.7
-                    , tasty-hedgehog >= 0.2 && < 0.3
+                    , hedgehog >= 0.6 && < 1.1
+                    , hedgehog-fn >= 0.6 && < 1.1
+                    , tasty-hedgehog >= 0.2 && < 1.1
                     , transformers >=0.4.1 && <5.5
                     , mtl >=2.2 && <2.3
 


### PR DESCRIPTION
This commit relaxes the upper bounds for library and tests, allowing the
library to compile and be tested on recent versions of GHC.